### PR TITLE
Fix balance update issue after Razorpay payment

### DIFF
--- a/BALANCE_UPDATE_FIX.md
+++ b/BALANCE_UPDATE_FIX.md
@@ -1,0 +1,67 @@
+# Razorpay Balance Update Fix
+
+## Problem Identified
+The balance was not updating after successful Razorpay payments due to a **race condition** between the frontend payment handler and backend verification process.
+
+### Root Cause
+1. **Frontend Payment Handler**: Executed immediately when Razorpay confirmed payment
+2. **Backend Verification**: Happened asynchronously via callback URL 
+3. **Race Condition**: `fetchUserProfile()` was called too early (after 2 seconds), before backend verification completed
+
+## Solution Implemented
+
+### 1. Frontend Changes (`frontend/src/components/Amount/AddAmountModel.jsx`)
+- **Removed**: Arbitrary 2-second timeout approach
+- **Added**: Transaction status polling mechanism
+- **Improved**: Proper error handling and user feedback
+
+#### Key Features:
+- **Polling Function**: Checks transaction status every 2 seconds for up to 60 seconds
+- **Smart Retry**: Uses new `/amount/status/:txn_id` endpoint for reliable status checking
+- **User Feedback**: Proper toast notifications for each stage of the process
+
+### 2. Backend Changes
+
+#### New Service Method (`backend/src/service/AmountService.js`)
+```javascript
+static async checkTransactionStatus(txn_id, user)
+```
+- Returns structured transaction status: `'completed'`, `'failed'`, or `'pending'`
+- Includes proper authorization checks
+- Provides detailed transaction and account information
+
+#### New Controller Method (`backend/src/controller/AmountController.js`)
+```javascript
+static checkTransactionStatus = async(req,res)
+```
+
+#### New API Endpoint (`backend/src/router/amount/index.js`)
+```
+GET /amount/status/:txn_id
+```
+- Authenticated endpoint for checking transaction status
+- More reliable than debug endpoints
+
+## How It Works Now
+
+1. **Payment Initiation**: User clicks Pay → Razorpay modal opens
+2. **Payment Success**: Razorpay confirms payment → Handler starts polling
+3. **Backend Processing**: Callback URL verifies payment → Updates balance in database
+4. **Status Polling**: Frontend polls `/amount/status/:txn_id` every 2 seconds
+5. **Balance Update**: Once status = 'completed' → `fetchUserProfile()` → Balance updated in UI
+
+## Benefits
+
+✅ **Eliminates Race Conditions**: Waits for actual backend verification completion
+✅ **Reliable Balance Updates**: No more manual page refreshes needed
+✅ **Better UX**: Clear feedback throughout the payment process  
+✅ **Error Handling**: Proper handling of failed payments
+✅ **Scalable**: Can handle varying backend processing times
+
+## Testing
+
+The fix ensures:
+- Balance updates automatically after successful payments
+- Failed payments are properly handled
+- No more "refresh the page" scenarios
+- Consistent experience across different network conditions

--- a/backend/src/controller/AmountController.js
+++ b/backend/src/controller/AmountController.js
@@ -33,6 +33,16 @@ class AmountController{
         }
     }
 
+    // New method for checking transaction status
+    static checkTransactionStatus = async(req,res)=>{
+        try {
+            const res_obj = await AmountService.checkTransactionStatus(req.params.txn_id, req.user)
+            res.status(200).send(res_obj)
+        } catch (error) {
+            res.status(500).send({error: error.message})
+        }
+    }
+
     static debugAccount = async(req,res)=>{
         try {
             const res_obj = await AmountService.debugAccount(req.params.account_id, req.user)

--- a/backend/src/router/amount/index.js
+++ b/backend/src/router/amount/index.js
@@ -13,6 +13,9 @@ router.post('/add-account',AuthMiddleware,AmountValidation.addAccount,Validation
 router.post('/payment/:txn_id',AmountController.verifyPayment)
 router.get('/transactions',AuthMiddleware,AmountController.getAllTransactions)
 
+// New endpoint for checking transaction status
+router.get('/status/:txn_id', AuthMiddleware, AmountController.checkTransactionStatus)
+
 // Debug endpoints for troubleshooting
 router.get('/debug/transaction/:txn_id', AuthMiddleware, AmountController.debugTransaction)
 router.get('/debug/account/:account_id', AuthMiddleware, AmountController.debugAccount)


### PR DESCRIPTION
Implement transaction status polling to fix a race condition where user balance was not updating after Razorpay payments.

Previously, the frontend would attempt to refresh the user's balance immediately after Razorpay confirmed payment. However, the actual balance update on the backend occurred asynchronously via a callback URL. This created a race condition where the frontend's `fetchUserProfile()` was often called before the backend had completed the verification and balance update, leading to an outdated balance being displayed.