### PR TITLE
Fix Next.js build errors

### DIFF
--- a/frontend/src/app/(root)/recharge-success/page.jsx
+++ b/frontend/src/app/(root)/recharge-success/page.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { useSearchParams } from 'next/navigation';
 import HeaderName from '@/components/HeaderName';

--- a/frontend/src/app/(root)/transfer-success/page.jsx
+++ b/frontend/src/app/(root)/transfer-success/page.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { useSearchParams } from 'next/navigation';
 import HeaderName from '@/components/HeaderName';


### PR DESCRIPTION
Add `"use client"` directive to `recharge-success` and `transfer-success` pages to resolve Next.js build errors.